### PR TITLE
Document poll parameters and removing port parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ You should be able to call this from telegraf now using execd:
   command = ["/path/to/dnsmasq-tp_binary"]
   # for using plugin
   # command = ["/path/to/dnsmasq-tp_binary", "-config", "/path/to/plugin.conf"]
+  # for using with custom scraping interval (there also exists a parameter called "pollIntervalDisabled")
+  # command = ["/path/to/dnsmasq-tp_binary", "-config", "/path/to/plugin.conf" "-pollInterval", "30s"]
+
   signal = "none"
   
 # sample output: write metrics to stdout
@@ -43,11 +46,9 @@ You should be able to call this from telegraf now using execd:
 ```toml
 # Read metrics about dnsmasq dns side.
 [[inputs.dnsmasq]]
-  # Dnsmasq server IP address.
-  server = "127.0.0.1"
-  
-  # Dnsmasq server port.
-  port = 53
+  # Dnsmasq server IP address and port.
+  server = "127.0.0.1:53"
+
 ```
 
 # Metrics:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You should be able to call this from telegraf now using execd:
   # for using plugin
   # command = ["/path/to/dnsmasq-tp_binary", "-config", "/path/to/plugin.conf"]
   # for using with custom scraping interval (there also exists a parameter called "pollIntervalDisabled")
-  # command = ["/path/to/dnsmasq-tp_binary", "-config", "/path/to/plugin.conf" "-pollInterval", "30s"]
+  # command = ["/path/to/dnsmasq-tp_binary", "-config", "/path/to/plugin.conf", "-pollInterval", "30s"]
 
   signal = "none"
   
@@ -69,5 +69,5 @@ You should be able to call this from telegraf now using execd:
 # Example Output:
 
 ```
-dnsmasq,host=localhost,server=127.0.0.1,port=53 insertions=0,evictions=0,misses=0,hits=12,auth=0,queries=0,queries_failed=0,cachesize=150 1598519060000000000
+dnsmasq,host=localhost,server=127.0.0.1:53 insertions=0,evictions=0,misses=0,hits=12,auth=0,queries=0,queries_failed=0,cachesize=150 1598519060000000000
 ```

--- a/plugins/inputs/dnsmasq/dnsmasq.go
+++ b/plugins/inputs/dnsmasq/dnsmasq.go
@@ -22,19 +22,13 @@ const (
 type Dnsmasq struct {
 	c *dns.Client
 
-	// Dnsmasq server IP address
+	// Dnsmasq server IP address and port
 	Server string
-
-	// Dnsmasq server port
-	Port int
 }
 
 var sampleConfig = `
-  ## Dnsmasq server IP address.
-  # server = "127.0.0.1"
-  #
-  ## Dnsmasq server port.
-  # port = 53
+  ## Dnsmasq server IP address and port.
+  # server = "127.0.0.1:53"
 `
 
 func (d *Dnsmasq) SampleConfig() string {
@@ -49,8 +43,7 @@ func (d *Dnsmasq) Gather(acc telegraf.Accumulator) error {
 	d.setDefaultValues()
 	fields := make(map[string]interface{}, 2)
 	tags := map[string]string{
-		"server": d.Server,
-		"port":   fmt.Sprint(d.Port),
+		"server": d.Server
 	}
 	msg := &dns.Msg{
 		MsgHdr: dns.MsgHdr{
@@ -115,10 +108,7 @@ func (d *Dnsmasq) Gather(acc telegraf.Accumulator) error {
 
 func (d *Dnsmasq) setDefaultValues() {
 	if d.Server == "" {
-		d.Server = "127.0.0.1"
-	}
-	if d.Port == 0 {
-		d.Port = 53
+		d.Server = "127.0.0.1:53"
 	}
 }
 

--- a/plugins/inputs/dnsmasq/dnsmasq_test.go
+++ b/plugins/inputs/dnsmasq/dnsmasq_test.go
@@ -13,7 +13,6 @@ import (
 // Test should with dnsmasq server,or run container with
 // `docker run -p 53:53/tcp -p 53:53/udp --cap-add=NET_ADMIN andyshinn/dnsmasq:2.75`
 var server = "127.0.0.1:53"
-var port = 53
 
 func TestGathering(t *testing.T) {
 	if testing.Short() {
@@ -24,8 +23,7 @@ func TestGathering(t *testing.T) {
 	}
 	var dnsmasqConfig = Dnsmasq{
 		c:      dnsClient,
-		Server: server,
-		Port:   port,
+		Server: server
 	}
 	var acc testutil.Accumulator
 
@@ -55,6 +53,5 @@ func TestSettingDefaultValues(t *testing.T) {
 
 	dnsmasqConfig.setDefaultValues()
 
-	assert.Equal(t, "127.0.0.1", dnsmasqConfig.Server, "Default dnsmasq server ip not equal \"127.0.0.1\"")
-	assert.Equal(t, 53, dnsmasqConfig.Port, "Default dnsmasq server port not equal 53")
+	assert.Equal(t, "127.0.0.1:53", dnsmasqConfig.Server, "Default dnsmasq server ip and port not equal \"127.0.0.1:53\"")
 }


### PR DESCRIPTION
Searched a while for poll parameters which are not mentioned at readme so far. So they should be documented...
Also removed port parameter, because it was not implemented correctly (so port parameters havent worked).
I think without port parameter its easier and other plugins are also working with server:port, it a popular approach to merge them...