### PR TITLE
new line needs comma in a map

### DIFF
--- a/plugins/inputs/dnsmasq/dnsmasq.go
+++ b/plugins/inputs/dnsmasq/dnsmasq.go
@@ -43,7 +43,7 @@ func (d *Dnsmasq) Gather(acc telegraf.Accumulator) error {
 	d.setDefaultValues()
 	fields := make(map[string]interface{}, 2)
 	tags := map[string]string{
-		"server": d.Server
+		"server": d.Server,
 	}
 	msg := &dns.Msg{
 		MsgHdr: dns.MsgHdr{


### PR DESCRIPTION
build was failing with following at v1.19.0
`plugins/inputs/dnsmasq/dnsmasq.go:46:21: syntax error: unexpected newline in composite literal; possibly missing comma or } `